### PR TITLE
Oura Ringの歩数は仕事のある日は1000歩/休みの日は500歩くらい多く出るので調整する

### DIFF
--- a/.github/workflows/put_steps_to_pixela.yml
+++ b/.github/workflows/put_steps_to_pixela.yml
@@ -43,16 +43,25 @@ jobs:
         run: |
           go install github.com/a-know/pi/cmd/pi@latest
 
+      - name: Corrects the Number of Steps
+        id: correct
+        # Oura Ringの歩数は仕事のある日は1000歩/休みの日は500歩くらい多く出るので調整する
+        # https://github.com/orgs/community/discussions/25386#discussioncomment-3247730
+        run: |
+          echo "steps=$((${{ env.STEPS }} - 850))" >> $GITHUB_OUTPUT
+        env:
+          STEPS: ${{ steps.count.outputs.steps }}
+
       - name: Put Data to Pixela
         run: |
           pi pixel post -u ${{ env.USER_NAME }} -g ${{ env.GRAPH_NAME }} -d ${{ env.DATE }} -q ${{ env.QUANTITY }}
+          echo "steps=${{ env.QUANTITY }}" >> $GITHUB_OUTPUT
         env:
           PIXELA_USER_TOKEN: ${{ secrets.PIXELA_USER_TOKEN }}
           USER_NAME: mom0tomo
           GRAPH_NAME: pedometer
           DATE: ${{ steps.check.outputs.date }}
-          # Oura Ringの歩数は仕事のある日は1000歩/休みの日は500歩くらい多く出るので調整する
-          QUANTITY: ${{ steps.count.outputs.steps }} - 850
+          QUANTITY: ${{ steps.correct.outputs.steps }}
 
       - name: Notify Slack on Success
         if: success()


### PR DESCRIPTION
GHAでの計算の方法が間違っていた。
https://github.com/orgs/community/discussions/25386#discussioncomment-3247730
```
Github actions doesn’t support math operations in expressions inside ${{  }}. You could add up these two numbers in bash script and then use set-env command to give its value to an environment variable, please try my example: 

on: push
jobs:
build:
runs-on: ubuntu-latest
steps:
- name: run number with offset
env:
NUM: ${{ github.run_number }}
run: |
echo ::set-env name=GITHUB_RUN_NUMBER_WITH_OFFSET::$(($NUM+200))
- run: echo $GITHUB_RUN_NUMBER_WITH_OFFSET
```